### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/2000093653/c8829ab6-82dc-4e90-9a01-d7cd07608b76/da47a1ba-e58d-434e-a2c9-37735874cf3c/_apis/work/boardbadge/12aa9268-d620-4514-b9fa-4fbced21b44b)](https://dev.azure.com/2000093653/c8829ab6-82dc-4e90-9a01-d7cd07608b76/_boards/board/t/da47a1ba-e58d-434e-a2c9-37735874cf3c/Microsoft.RequirementCategory)
 # Skill matrix app
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#7](https://dev.azure.com/2000093653/c8829ab6-82dc-4e90-9a01-d7cd07608b76/_workitems/edit/7). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.